### PR TITLE
Add standard Survey123 formula parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Survey123Py is a tool designed to simplify the creation of Survey123 forms by offering an alternative to the traditional Microsoft Excel workflow. Instead of managing complex forms in Excel with 40+ columns Survey123Py lets you define your form structure using YAML — making it easier to read, maintain, and track changes using version control systems like Git.
 
-In it's current form, it only creates the form and does not validate the output. Long term goals include to add data validation similar to Survey123 Connect.
+This package aims to enhance the developer experience by adding custom modules such as the `FormPreviewer` which allows you to verify output using samples inputs using the special field `survey123py::preview_input` in your YAML config.
+
+In it's current form it is able to validate and parse formulas and variables the form. However, not all validation and parsing is included yet.
 
 **Note**: Survey123Py does not publish your form. You’ll still need to use Survey123 Connect to publish the final version.
 

--- a/survey123py/form.py
+++ b/survey123py/form.py
@@ -199,7 +199,6 @@ class FormData:
             if sheet_data is None or sheet_name not in target_sheets:
                 continue
             
-            print("Writing to sheet:", sheet_name)
             ws = wb[sheet_name]
             excel_col = None
             excel_row = None

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -79,3 +79,14 @@ def cos(value: float) -> float:
     """
     value = float(value)
     return math.cos(value)
+
+def sin(value: float) -> float:
+    """
+    Returns the sine of the value in radians.
+
+    Example:
+
+    `sin(${question_one})`
+    """
+    value = float(value)
+    return math.sin(value)

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -204,3 +204,27 @@ def asin(value: float) -> float:
     if value < -1 or value > 1:
         raise ValueError("Value must be in the range [-1, 1]")
     return math.asin(value)
+
+def atan(value: float) -> float:
+    """
+    Returns the arctangent of the value in radians.
+
+    Example:
+
+    `atan(${question_one})`
+    """
+    value = float(value)
+    return math.atan(value)
+
+def atan2(y: float, x: float) -> float:
+    """
+    Returns the arctangent of y/x in radians using the signs of both arguments
+    to determine the quadrant of the result.
+
+    Example:
+
+    `atan2(${question_one}, ${question_two})`
+    """
+    y = float(y)
+    x = float(x)
+    return math.atan2(y, x)

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -1,5 +1,6 @@
 # All formulas available in Survey123 are implemented here.
 # For full documentation, see: https://doc.arcgis.com/en/survey123/desktop/create-surveys/xlsformformulas.htm
+from datetime import datetime
 import math
 
 def if_(statement, a, b) -> bool:
@@ -21,6 +22,49 @@ def if_(statement, a, b) -> bool:
         return b
     else:
         raise ValueError(f"Value '{statement}' is unsupported. The statement must be a boolean or a string that can be evaluated to a boolean.")
+
+def int_(value: str) -> int:
+    """
+    Converts the value to an integer. If this function is empty, it will return NaN and the question will remain empty.
+
+    Example:
+
+    `int(${question_one})`
+    """
+    if value is None or value == '':
+        return None  # Return None for empty values to keep the question empty
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"Value '{value}' is unsupported. The value must be a valid integer.")
+
+def boolean_from_string(value: str) -> bool:
+    """
+    Returns true if the string provided is 'true' or '1'. Otherwise, returns false.
+
+    Example:
+
+    `boolean_from_string(${question_one})`
+    """
+    if value.lower() in ['true', '1']:
+        return True
+    elif value.lower() in ['false', '0']:
+        return False
+    else:
+        raise ValueError(f"Value '{value}' is unsupported. The value must be 'true', 'false', '1', or '0'.")
+    
+def format_date(datetime_val: str, format: str) -> str:
+    """
+    Fits an existing date or time value to a defined format. Input must be a date object.
+
+    Example:
+
+    `format_date(${question_one}, '%Y-%m-%d')`
+    """
+    # Convert milliseconds to seconds
+    dt = datetime.fromtimestamp(datetime_val / 1000)
+    # Format using the user-provided format string
+    return dt.strftime(format)
 
 def concat(*args):
     """

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -1,5 +1,6 @@
 # All formulas available in Survey123 are implemented here.
 # For full documentation, see: https://doc.arcgis.com/en/survey123/desktop/create-surveys/xlsformformulas.htm
+import math
 
 def if_(statement, a, b) -> bool:
     """
@@ -53,3 +54,17 @@ def ends_with(string: str, substring: str):
     `ends-with(${question_one}, 'hand.')z`
     """
     return string.endswith(substring)
+
+def acos(value: float) -> float:
+    """
+    Returns the arccosine of the value in radians.
+    Value must be in the range [-1, 1].
+
+    Example:
+
+    `acos(${question_one})`
+    """
+    value = float(value)
+    if value < -1 or value > 1:
+        raise ValueError("Value must be in the range [-1, 1]")
+    return math.acos(value)

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -1,0 +1,55 @@
+# All formulas available in Survey123 are implemented here.
+# For full documentation, see: https://doc.arcgis.com/en/survey123/desktop/create-surveys/xlsformformulas.htm
+
+def if_(statement, a, b) -> bool:
+    """
+    If the conditstatemention evaluates to true, returns a; otherwise, returns b. For more information, see [Conditional expressions](https://doc.arcgis.com/en/survey123/desktop/create-surveys/xlsformexpressions.htm#ESRI_SECTION1_9C76E7A8118B493DB6A69AFA4AE37B9F).
+    Note: String must be converted within survey123py from `if()` to `if_()` to avoid conflict with Python's built-in `if` statement.
+
+    Example:
+
+    if(selected(${question_one}, 'yes'), 'yes', 'no')
+    """
+    if eval(statement):
+        return a
+    return b
+
+def concat(*args):
+    """
+    Returns the concatenation of the string values.
+
+    Example:
+
+    `concat(${question_one}, ' and ', ${question_two})`
+    """
+    return ''.join(args)
+
+def contains(string: str, substring: str):
+    """
+    Returns true if the given string contains the substring.
+
+    Example:
+
+    `contains(${question_one}, 'red')`
+    """
+    return substring in string
+
+def starts_with(string: str, substring: str):
+    """
+    Returns true if the given string starts with the substring.
+
+    Example:
+
+    `starts-with(${question_one}, 'red')`
+    """
+    return string.startswith(substring)
+
+def ends_with(string: str, substring: str):
+    """
+    Returns true if the given string ends with the substring.
+
+    Example:
+
+    `ends-with(${question_one}, 'hand.')z`
+    """
+    return string.endswith(substring)

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -3,6 +3,9 @@
 from datetime import datetime
 import math
 import builtins
+import uuid
+import random
+import re
 
 def if_(statement, a, b) -> bool:
     """
@@ -631,3 +634,86 @@ def number(value) -> float:
         return float(value)
     except (ValueError, TypeError):
         return None
+
+def version(survey_settings=None) -> str:
+    """
+    Returns the version specified in the settings section of the YAML file.
+    If no version is specified or survey_settings is None, returns empty string.
+    
+    Example:
+    
+    `version()`
+    """
+    if survey_settings and isinstance(survey_settings, dict) and "version" in survey_settings:
+        return str(survey_settings["version"])
+    return ""
+
+def uuid() -> str:
+    """
+    Generates and returns a universally unique identifier (UUID).
+    
+    Example:
+    
+    `uuid()`
+    """
+    import uuid as uuid_module
+    return str(uuid_module.uuid4())
+
+def today() -> int:
+    """
+    Returns the current date as a timestamp in milliseconds (without time component).
+    Similar to now() but only includes the date part.
+    
+    Example:
+    
+    `today()`
+    """
+    # Get current date and set time to midnight
+    today_date = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    return int(today_date.timestamp() * 1000)
+
+def sum(*args) -> float:
+    """
+    Returns the sum of all numeric arguments.
+    Non-numeric values are ignored.
+    
+    Example:
+    
+    `sum(${field1}, ${field2}, ${field3})`
+    """
+    total = 0
+    for arg in args:
+        if arg is not None and arg != "":
+            try:
+                total += float(arg)
+            except (ValueError, TypeError):
+                pass  # Skip non-numeric values
+    return total
+
+def regex(pattern: str, text: str) -> bool:
+    """
+    Returns true if the text matches the regular expression pattern.
+    
+    Example:
+    
+    `regex('[0-9]+', ${phone_number})`
+    """
+    if not pattern or not text:
+        return False
+    
+    try:
+        return bool(re.search(str(pattern), str(text)))
+    except re.error:
+        # Invalid regex pattern
+        return False
+
+def random() -> float:
+    """
+    Returns a random decimal number between 0 and 1 (exclusive of 1).
+    
+    Example:
+    
+    `random()`
+    """
+    import random as random_module
+    return random_module.random()

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -2,6 +2,7 @@
 # For full documentation, see: https://doc.arcgis.com/en/survey123/desktop/create-surveys/xlsformformulas.htm
 from datetime import datetime
 import math
+import builtins
 
 def if_(statement, a, b) -> bool:
     """
@@ -228,3 +229,114 @@ def atan2(y: float, x: float) -> float:
     y = float(y)
     x = float(x)
     return math.atan2(y, x)
+
+def tan(value: float) -> float:
+    """
+    Returns the tangent of the value in radians.
+
+    Example:
+
+    `tan(${question_one})`
+    """
+    value = float(value)
+    return math.tan(value)
+
+def exp(value: float) -> float:
+    """
+    Returns e raised to the power of the value.
+
+    Example:
+
+    `exp(${question_one})`
+    """
+    value = float(value)
+    return math.exp(value)
+
+def exp10(value: float) -> float:
+    """
+    Returns 10 raised to the power of the value.
+
+    Example:
+
+    `exp10(${question_one})`
+    """
+    value = float(value)
+    return math.pow(10, value)
+
+def log(value: float) -> float:
+    """
+    Returns the natural logarithm of the value.
+    Value must be positive.
+
+    Example:
+
+    `log(${question_one})`
+    """
+    value = float(value)
+    if value <= 0:
+        raise ValueError("Value must be positive")
+    return math.log(value)
+
+def log10(value: float) -> float:
+    """
+    Returns the base-10 logarithm of the value.
+    Value must be positive.
+
+    Example:
+
+    `log10(${question_one})`
+    """
+    value = float(value)
+    if value <= 0:
+        raise ValueError("Value must be positive")
+    return math.log10(value)
+
+def pi() -> float:
+    """
+    Returns the mathematical constant π (pi).
+
+    Example:
+
+    `pi()`
+    """
+    return math.pi
+
+def pow(base: float, exponent: float) -> float:
+    """
+    Returns base raised to the power of exponent.
+
+    Example:
+
+    `pow(${question_one}, ${question_two})`
+    """
+    base = float(base)
+    exponent = float(exponent)
+    return math.pow(base, exponent)
+
+def round(value: float, ndigits: int = 0) -> float:
+    """
+    Returns the value rounded to the given number of digits after the decimal point.
+    If ndigits is omitted or is None, it returns the nearest integer.
+
+    Example:
+
+    `round(${question_one}, 2)`
+    """
+    value = float(value)
+    if ndigits == 0:
+        return float(builtins.round(value))
+    return builtins.round(value, ndigits)
+
+def sqrt(value: float) -> float:
+    """
+    Returns the square root of the value.
+    Value must be non-negative.
+
+    Example:
+
+    `sqrt(${question_one})`
+    """
+    value = float(value)
+    if value < 0:
+        raise ValueError("Value must be non-negative")
+    return math.sqrt(value)

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -521,3 +521,113 @@ def decimal_date_time(timestamp) -> float:
         return delta.total_seconds() / (24 * 60 * 60)  # Convert to days
     except (ValueError, TypeError):
         raise ValueError(f"Value '{timestamp}' is not a valid timestamp")
+
+def false() -> bool:
+    """
+    Returns the boolean value false.
+    
+    Example:
+
+    `false()`
+    """
+    return False
+
+def join(separator: str, *args) -> str:
+    """
+    Joins multiple values with the specified separator.
+    Only non-empty values are included in the result.
+    
+    Example:
+
+    `join(' - ', ${field1}, ${field2}, ${field3})`
+    """
+    # Filter out None and empty string values
+    valid_args = [str(arg) for arg in args if arg is not None and arg != ""]
+    return str(separator).join(valid_args)
+
+def max(*args):
+    """
+    Returns the maximum value from the arguments.
+    Only considers numeric values.
+    
+    Example:
+
+    `max(${field1}, ${field2}, ${field3})`
+    """
+    numeric_args = []
+    for arg in args:
+        if arg is not None and arg != "":
+            try:
+                numeric_args.append(float(arg))
+            except (ValueError, TypeError):
+                pass  # Skip non-numeric values
+    
+    if not numeric_args:
+        return None
+    
+    return builtins.max(numeric_args)
+
+def min(*args):
+    """
+    Returns the minimum value from the arguments.
+    Only considers numeric values.
+    
+    Example:
+
+    `min(${field1}, ${field2}, ${field3})`
+    """
+    numeric_args = []
+    for arg in args:
+        if arg is not None and arg != "":
+            try:
+                numeric_args.append(float(arg))
+            except (ValueError, TypeError):
+                pass  # Skip non-numeric values
+    
+    if not numeric_args:
+        return None
+    
+    return builtins.min(numeric_args)
+
+def not_(value) -> bool:
+    """
+    Returns the logical NOT of the value.
+    Note: Function name uses underscore to avoid conflict with Python's 'not' keyword.
+    
+    Example:
+
+    `not(${boolean_field})`
+    """
+    # Convert to boolean first, then negate
+    return not boolean(value)
+
+def now() -> int:
+    """
+    Returns the current date and time as a timestamp in milliseconds.
+    
+    Example:
+
+    `now()`
+    """
+    return int(datetime.now().timestamp() * 1000)
+
+def number(value) -> float:
+    """
+    Converts the value to a number (float).
+    Returns None for values that cannot be converted.
+    
+    Example:
+
+    `number(${text_field})`
+    """
+    if value is None or value == "":
+        return None
+    
+    # Strip quotes if present
+    if isinstance(value, str) and value.startswith("'") and value.endswith("'"):
+        value = value[1:-1]
+    
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -382,3 +382,23 @@ def selected_at(multi_select_answer: str, index: int) -> str:
         return ""
     
     return selections[index]
+
+def jr_choice_name(choice_value: str, question_name: str) -> str:
+    """
+    Returns the label/display text for a given choice value from a specified question.
+    This is a simplified implementation that returns the choice_value since we don't have
+    access to the choice definitions in the formula context.
+    
+    In a real Survey123 form, this would look up the label from the choices sheet
+    based on the question's choice list.
+
+    Example:
+
+    `jr:choice-name(${priority}, 'priority')`
+    """
+    # In a real implementation, this would:
+    # 1. Look up the question to find its choice list
+    # 2. Look up the choice_value in that choice list
+    # 3. Return the corresponding label
+    # For now, we return the choice_value as a placeholder
+    return str(choice_value) if choice_value else ""

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -11,9 +11,16 @@ def if_(statement, a, b) -> bool:
 
     if(selected(${question_one}, 'yes'), 'yes', 'no')
     """
-    if eval(statement):
-        return a
-    return b
+    if isinstance(statement, str):
+        if eval(statement):
+            return a
+        return b
+    elif isinstance(statement, bool):
+        if statement:
+            return a
+        return b
+    else:
+        raise ValueError(f"Value '{statement}' is unsupported. The statement must be a boolean or a string that can be evaluated to a boolean.")
 
 def concat(*args):
     """

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -68,3 +68,14 @@ def acos(value: float) -> float:
     if value < -1 or value > 1:
         raise ValueError("Value must be in the range [-1, 1]")
     return math.acos(value)
+
+def cos(value: float) -> float:
+    """
+    Returns the cosine of the value in radians.
+
+    Example:
+
+    `cos(${question_one})`
+    """
+    value = float(value)
+    return math.cos(value)

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -340,3 +340,45 @@ def sqrt(value: float) -> float:
     if value < 0:
         raise ValueError("Value must be non-negative")
     return math.sqrt(value)
+
+def selected(multi_select_answer: str, choice_value: str) -> bool:
+    """
+    Returns true if the choice_value is selected in the multi-select answer.
+    The multi_select_answer should be a comma-separated string of selected values.
+
+    Example:
+
+    `selected(${multi_select_question}, 'option1')`
+    """
+    if not multi_select_answer or not choice_value:
+        return False
+    
+    # Convert to string and split by commas to get individual selections
+    selections = str(multi_select_answer).split(',')
+    # Strip whitespace from each selection
+    selections = [sel.strip() for sel in selections]
+    return str(choice_value) in selections
+
+def selected_at(multi_select_answer: str, index: int) -> str:
+    """
+    Returns the choice value at the specified index (0-based) in the multi-select answer.
+    Returns empty string if index is out of bounds.
+    The multi_select_answer should be a comma-separated string of selected values.
+
+    Example:
+
+    `selected-at(${multi_select_question}, 0)`
+    """
+    if not multi_select_answer:
+        return ""
+    
+    # Convert to string and split by commas to get individual selections
+    selections = str(multi_select_answer).split(',')
+    # Strip whitespace from each selection
+    selections = [sel.strip() for sel in selections]
+    
+    # Check if index is valid
+    if index < 0 or index >= len(selections):
+        return ""
+    
+    return selections[index]

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -48,9 +48,42 @@ def starts_with(string: str, substring: str):
 
     Example:
 
-    `starts-with(${question_one}, 'red')`
+    `starts_with(${question_one}, 'red')`
     """
     return string.startswith(substring)
+
+def string_length(string: str) -> int:
+    """
+    Returns the length of the string.
+
+    Example:
+
+    `string_length(${question_one})`
+    """
+    return len(string)
+
+def string(value: str) -> str:
+    """
+    Converts the value to a string.
+
+    Example:
+
+    `string(${question_one})`
+    """
+    return str(value)
+
+def substr(string: str, start: int, end: int = None) -> str:
+    """
+    Returns a substring of the string starting at the specified index.
+    If length is not specified, returns the substring from start to the end of the string.
+
+    Example:
+
+    `substr(${question_one}, 2, 5)`
+    """
+    if end is None:
+        return string[start:]
+    return string[start:start + end]
 
 def ends_with(string: str, substring: str):
     """

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -53,6 +53,22 @@ def boolean_from_string(value: str) -> bool:
     else:
         raise ValueError(f"Value '{value}' is unsupported. The value must be 'true', 'false', '1', or '0'.")
     
+def date(value: str) -> str:
+    """
+    Converts a number or string to a Survey123 date object (unix timestamp in milliseconds), without preserving time.
+
+    Example:
+
+    `date(${question_one})`
+    """
+    if value is None or value == '':
+        return None  # Return None for empty values to keep the question empty
+    try:
+        outval = datetime.strptime(value, '%Y-%m-%d').timestamp() * 1000
+        return int(outval)
+    except ValueError:
+        raise ValueError(f"Value '{value}' is unsupported. The value must be a valid date in 'YYYY-MM-DD' format.")
+
 def format_date(datetime_val: str, format: str) -> str:
     """
     Fits an existing date or time value to a defined format. Input must be a date object.

--- a/survey123py/formulas.py
+++ b/survey123py/formulas.py
@@ -90,3 +90,17 @@ def sin(value: float) -> float:
     """
     value = float(value)
     return math.sin(value)
+
+def asin(value: float) -> float:
+    """
+    Returns the arcsine of the value in radians.
+    Value must be in the range [-1, 1].
+
+    Example:
+
+    `asin(${question_one})`
+    """
+    value = float(value)
+    if value < -1 or value > 1:
+        raise ValueError("Value must be in the range [-1, 1]")
+    return math.asin(value)

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -1,5 +1,6 @@
 import re
 import yaml
+from .formulas import *
 
 class FormPreviewer:
 
@@ -80,7 +81,7 @@ class FormPreviewer:
             matches = re.findall(self.var_pattern, value)
             if matches:
                 for match in matches:
-                    value = value.replace("${" + match + "}", ctx[match]["value"])
+                    value = value.replace("${" + match + "}", str(ctx[match]["value"]))
                 ctx[item["name"]] = {"value": value, "type": item.get("type")}
             # Check if value to be evaluated contains things that need to be replaced
             if "if(" in ctx[item["name"]]["value"]:

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -153,6 +153,7 @@ class FormPreviewer:
         """
         # Parse variables in the survey data
         self.output_data = self._parse_vars(self.output_data)
+        self.output_data = self._parse_formulas(self.output_data)
 
         if outpath:
             # Save the parsed survey data to a file if outpath is provided

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -42,7 +42,7 @@ class FormPreviewer:
         for item in self.output_data["survey"]:
             value = item.get("survey123py::preview_input")
             
-            if value:
+            if value or item.get("calculation"):
 
                 ctx[item["name"]] = {"value": "", "type": item.get("type")}
                 if item.get("type") == "integer":
@@ -58,7 +58,7 @@ class FormPreviewer:
 
                 for item2 in item["children"]:
                     value2 = item2.get("survey123py::preview_input")
-                    if value2:
+                    if value2 or item2.get("calculation"):
                         ctx[item2["name"]] = {"value": "", "type": item2.get("type")}
                         if item2.get("type") == "integer":
                             value2 = int(value2)

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -96,6 +96,12 @@ class FormPreviewer:
                 ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("boolean-from-string(", "boolean_from_string(")
             if "jr:choice-name(" in ctx[item["name"]]["value"]:
                 ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("jr:choice-name(", "jr_choice_name(")
+            if "count-selected(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("count-selected(", "count_selected(")
+            if "decimal-date-time(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("decimal-date-time(", "decimal_date_time(")
+            if "date-time(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("date-time(", "date_time(")
             ctx[item["name"]]["value"] = eval(ctx[item["name"]]["value"])
             if ctx[item["name"]]["type"] == "text" and not isinstance(ctx[item["name"]]["value"], bool):
                 # Need to escape quotes in the string so it can be used by eval() properly
@@ -177,6 +183,12 @@ class FormPreviewer:
                         value = value.replace("boolean-from-string(", "boolean_from_string(")
                     if "jr:choice-name(" in value:
                         value = value.replace("jr:choice-name(", "jr_choice_name(")
+                    if "count-selected(" in value:
+                        value = value.replace("count-selected(", "count_selected(")
+                    if "decimal-date-time(" in value:
+                        value = value.replace("decimal-date-time(", "decimal_date_time(")
+                    if "date-time(" in value:
+                        value = value.replace("date-time(", "date_time(")
                     survey_data["survey"][i][key] = eval(value)
 
         return survey_data

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -129,6 +129,10 @@ class FormPreviewer:
                 value = value.replace("date-time(", "date_time(")
             if "not(" in value:
                 value = value.replace("not(", "not_(")
+            # Handle version() function
+            if "version()" in value:
+                survey_settings = self.output_data.get("settings", {})
+                value = value.replace("version()", f"version({survey_settings})")
             
             # Store constraint result in context for evaluation
             constraint_key = f"{item['name']}_constraint"
@@ -138,30 +142,36 @@ class FormPreviewer:
         for item in [x for x in self.output_data["survey"] if "calculation" in x]:
             if item["name"] in ctx:
                 # Check if value to be evaluated contains things that need to be replaced
-                if "if(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("if(", "if_(")
-                if "starts-with(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("starts-with(", "starts_with(")
-                if "int(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("int(", "int_(")
-                if "format-date(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("format-date(", "format_date(")
-                if "boolean-from-string(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("boolean-from-string(", "boolean_from_string(")
-                if "jr:choice-name(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("jr:choice-name(", "jr_choice_name(")
-                if "count-selected(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("count-selected(", "count_selected(")
-                if "decimal-date-time(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("decimal-date-time(", "decimal_date_time(")
-                if "date-time(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("date-time(", "date_time(")
-                if "not(" in ctx[item["name"]]["value"]:
-                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("not(", "not_(")
-                ctx[item["name"]]["value"] = eval(ctx[item["name"]]["value"])
-            if ctx[item["name"]]["type"] == "text" and not isinstance(ctx[item["name"]]["value"], bool):
-                # Need to escape quotes in the string so it can be used by eval() properly
-                ctx[item["name"]]["value"] = f"\"{ctx[item['name']]['value']}\""
+                # Convert to string first to handle function replacements
+                value_str = str(ctx[item["name"]]["value"])
+                if "if(" in value_str:
+                    value_str = value_str.replace("if(", "if_(")
+                if "starts-with(" in value_str:
+                    value_str = value_str.replace("starts-with(", "starts_with(")
+                if "int(" in value_str:
+                    value_str = value_str.replace("int(", "int_(")
+                if "format-date(" in value_str:
+                    value_str = value_str.replace("format-date(", "format_date(")
+                if "boolean-from-string(" in value_str:
+                    value_str = value_str.replace("boolean-from-string(", "boolean_from_string(")
+                if "jr:choice-name(" in value_str:
+                    value_str = value_str.replace("jr:choice-name(", "jr_choice_name(")
+                if "count-selected(" in value_str:
+                    value_str = value_str.replace("count-selected(", "count_selected(")
+                if "decimal-date-time(" in value_str:
+                    value_str = value_str.replace("decimal-date-time(", "decimal_date_time(")
+                if "date-time(" in value_str:
+                    value_str = value_str.replace("date-time(", "date_time(")
+                if "not(" in value_str:
+                    value_str = value_str.replace("not(", "not_(")
+                # Handle version() function by replacing it with version(survey_settings)
+                if "version()" in value_str:
+                    survey_settings = self.output_data.get("settings", {})
+                    value_str = value_str.replace("version()", f"version({survey_settings})")
+                ctx[item["name"]]["value"] = eval(value_str)
+                if ctx[item["name"]]["type"] == "text" and not isinstance(ctx[item["name"]]["value"], bool):
+                    # Need to escape quotes in the string so it can be used by eval() properly
+                    ctx[item["name"]]["value"] = f"\"{ctx[item['name']]['value']}\""
 
         return ctx
     
@@ -247,6 +257,10 @@ class FormPreviewer:
                         value = value.replace("date-time(", "date_time(")
                     if "not(" in value:
                         value = value.replace("not(", "not_(")
+                    # Handle version() function
+                    if "version()" in value:
+                        survey_settings = survey_data.get("settings", {})
+                        value = value.replace("version()", f"version({survey_settings})")
                     survey_data["survey"][i][key] = eval(value)
 
         return survey_data

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -45,7 +45,7 @@ class FormPreviewer:
         for item in self.output_data["survey"]:
             value = item.get("survey123py::preview_input")
             
-            if value or item.get("calculation"):
+            if value is not None or item.get("calculation"):
 
                 ctx[item["name"]] = {"value": "", "type": item.get("type")}
                 if item.get("type") == "integer":
@@ -53,7 +53,7 @@ class FormPreviewer:
                 elif item.get("type") == "decimal":
                     value = float(value)
                 ctx[item["name"]]["value"] = value
-                if item["type"] == "text":
+                if item["type"] == "text" and not isinstance(value, bool):
                     # Need to escape quotes in the string so it can be used by eval() properly
                     ctx[item["name"]]["value"] = f"\"{ctx[item['name']]['value']}\""
             
@@ -61,14 +61,14 @@ class FormPreviewer:
 
                 for item2 in item["children"]:
                     value2 = item2.get("survey123py::preview_input")
-                    if value2 or item2.get("calculation"):
+                    if value2 is not None or item2.get("calculation"):
                         ctx[item2["name"]] = {"value": "", "type": item2.get("type")}
                         if item2.get("type") == "integer":
                             value2 = int(value2)
                         elif item2.get("type") == "decimal":
                             value2 = float(value2)
                         ctx[item2["name"]]["value"] = value2
-                        if item2["type"] == "text":
+                        if item2["type"] == "text" and not isinstance(value2, bool):
                             # Need to escape quotes in the string so it can be used by eval() properly
                             ctx[item2["name"]]["value"] = f"\"{ctx[item2['name']]['value']}\""
         if len(ctx) == 0:
@@ -95,7 +95,7 @@ class FormPreviewer:
             if "boolean-from-string(" in ctx[item["name"]]["value"]:
                 ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("boolean-from-string(", "boolean_from_string(")
             ctx[item["name"]]["value"] = eval(ctx[item["name"]]["value"])
-            if ctx[item["name"]]["type"] == "text":
+            if ctx[item["name"]]["type"] == "text" and not isinstance(ctx[item["name"]]["value"], bool):
                 # Need to escape quotes in the string so it can be used by eval() properly
                 ctx[item["name"]]["value"] = f"\"{ctx[item['name']]['value']}\""
 

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -85,6 +85,14 @@ class FormPreviewer:
             # Check if value to be evaluated contains things that need to be replaced
             if "if(" in ctx[item["name"]]["value"]:
                 ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("if(", "if_(")
+            if "starts-with(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("starts-with(", "starts_with(")
+            if "int(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("int(", "int_(")
+            if "format-date(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("format-date(", "format_date(")
+            if "boolean-from-string(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("boolean-from-string(", "boolean_from_string(")
             ctx[item["name"]]["value"] = eval(ctx[item["name"]]["value"])
             if ctx[item["name"]]["type"] == "text":
                 # Need to escape quotes in the string so it can be used by eval() properly
@@ -156,6 +164,14 @@ class FormPreviewer:
                     # to be evaluated again for it to execute
                     if "if(" in value:
                         value = value.replace("if(", "if_(")
+                    if "starts-with(" in value:
+                        value = value.replace("starts-with(", "starts_with(")
+                    if "int(" in value:
+                        value = value.replace("int(", "int_(")
+                    if "format-date(" in value:
+                        value = value.replace("format-date(", "format_date(")
+                    if "boolean-from-string(" in value:
+                        value = value.replace("boolean-from-string(", "boolean_from_string(")
                     survey_data["survey"][i][key] = eval(value)
 
         return survey_data

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -94,6 +94,8 @@ class FormPreviewer:
                 ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("format-date(", "format_date(")
             if "boolean-from-string(" in ctx[item["name"]]["value"]:
                 ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("boolean-from-string(", "boolean_from_string(")
+            if "jr:choice-name(" in ctx[item["name"]]["value"]:
+                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("jr:choice-name(", "jr_choice_name(")
             ctx[item["name"]]["value"] = eval(ctx[item["name"]]["value"])
             if ctx[item["name"]]["type"] == "text" and not isinstance(ctx[item["name"]]["value"], bool):
                 # Need to escape quotes in the string so it can be used by eval() properly
@@ -173,6 +175,8 @@ class FormPreviewer:
                         value = value.replace("format-date(", "format_date(")
                     if "boolean-from-string(" in value:
                         value = value.replace("boolean-from-string(", "boolean_from_string(")
+                    if "jr:choice-name(" in value:
+                        value = value.replace("jr:choice-name(", "jr_choice_name(")
                     survey_data["survey"][i][key] = eval(value)
 
         return survey_data

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -83,26 +83,82 @@ class FormPreviewer:
                 for match in matches:
                     value = value.replace("${" + match + "}", str(ctx[match]["value"]))
                 ctx[item["name"]] = {"value": value, "type": item.get("type")}
-            # Check if value to be evaluated contains things that need to be replaced
-            if "if(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("if(", "if_(")
-            if "starts-with(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("starts-with(", "starts_with(")
-            if "int(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("int(", "int_(")
-            if "format-date(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("format-date(", "format_date(")
-            if "boolean-from-string(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("boolean-from-string(", "boolean_from_string(")
-            if "jr:choice-name(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("jr:choice-name(", "jr_choice_name(")
-            if "count-selected(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("count-selected(", "count_selected(")
-            if "decimal-date-time(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("decimal-date-time(", "decimal_date_time(")
-            if "date-time(" in ctx[item["name"]]["value"]:
-                ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("date-time(", "date_time(")
-            ctx[item["name"]]["value"] = eval(ctx[item["name"]]["value"])
+        
+        # Load constraint columns (handle dot operator here)
+        for item in [x for x in self.output_data["survey"] if "constraint" in x]:
+            value = item["constraint"]
+            
+            # Handle dot operator - replace "." with current field's value
+            if "." in value and "survey123py::preview_input" in item:
+                current_field_value = item["survey123py::preview_input"]
+                # Format the value appropriately for the constraint
+                if item.get("type") == "text" and not isinstance(current_field_value, bool):
+                    formatted_value = f'"{current_field_value}"'
+                else:
+                    formatted_value = str(current_field_value)
+                
+                # Replace standalone dots (not part of decimal numbers or method calls)
+                # Use regex to match dots that are not between digits or after alphanumeric characters
+                import re as regex_module
+                value = regex_module.sub(r'(?<!\w)\.(?!\d)', formatted_value, value)
+            
+            # Handle variable substitutions in constraints
+            matches = re.findall(self.var_pattern, value)
+            if matches:
+                for match in matches:
+                    value = value.replace("${" + match + "}", str(ctx[match]["value"]))
+            
+            # Apply function name conversions for constraints
+            if "if(" in value:
+                value = value.replace("if(", "if_(")
+            if "starts-with(" in value:
+                value = value.replace("starts-with(", "starts_with(")
+            if "int(" in value:
+                value = value.replace("int(", "int_(")
+            if "format-date(" in value:
+                value = value.replace("format-date(", "format_date(")
+            if "boolean-from-string(" in value:
+                value = value.replace("boolean-from-string(", "boolean_from_string(")
+            if "jr:choice-name(" in value:
+                value = value.replace("jr:choice-name(", "jr_choice_name(")
+            if "count-selected(" in value:
+                value = value.replace("count-selected(", "count_selected(")
+            if "decimal-date-time(" in value:
+                value = value.replace("decimal-date-time(", "decimal_date_time(")
+            if "date-time(" in value:
+                value = value.replace("date-time(", "date_time(")
+            if "not(" in value:
+                value = value.replace("not(", "not_(")
+            
+            # Store constraint result in context for evaluation
+            constraint_key = f"{item['name']}_constraint"
+            ctx[constraint_key] = {"value": value, "type": "constraint"}
+            
+        # Check if calculation values need function name replacements
+        for item in [x for x in self.output_data["survey"] if "calculation" in x]:
+            if item["name"] in ctx:
+                # Check if value to be evaluated contains things that need to be replaced
+                if "if(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("if(", "if_(")
+                if "starts-with(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("starts-with(", "starts_with(")
+                if "int(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("int(", "int_(")
+                if "format-date(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("format-date(", "format_date(")
+                if "boolean-from-string(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("boolean-from-string(", "boolean_from_string(")
+                if "jr:choice-name(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("jr:choice-name(", "jr_choice_name(")
+                if "count-selected(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("count-selected(", "count_selected(")
+                if "decimal-date-time(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("decimal-date-time(", "decimal_date_time(")
+                if "date-time(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("date-time(", "date_time(")
+                if "not(" in ctx[item["name"]]["value"]:
+                    ctx[item["name"]]["value"] = ctx[item["name"]]["value"].replace("not(", "not_(")
+                ctx[item["name"]]["value"] = eval(ctx[item["name"]]["value"])
             if ctx[item["name"]]["type"] == "text" and not isinstance(ctx[item["name"]]["value"], bool):
                 # Need to escape quotes in the string so it can be used by eval() properly
                 ctx[item["name"]]["value"] = f"\"{ctx[item['name']]['value']}\""
@@ -166,7 +222,7 @@ class FormPreviewer:
         """
         for i, item in enumerate(survey_data["survey"]):
             for key, value in item.items():
-                if key not in ["type", "name", "label", "survey123py::preview_input", "children"]:
+                if key not in ["type", "name", "label", "survey123py::preview_input", "children", "constraint"]:
 
                     # Note: This is called again (other one is in _load_ctx)
                     # This covers the survey data which is already parsed, for calculations it needs
@@ -189,10 +245,33 @@ class FormPreviewer:
                         value = value.replace("decimal-date-time(", "decimal_date_time(")
                     if "date-time(" in value:
                         value = value.replace("date-time(", "date_time(")
+                    if "not(" in value:
+                        value = value.replace("not(", "not_(")
                     survey_data["survey"][i][key] = eval(value)
 
         return survey_data
     
+    def _parse_constraints(self, survey_data: dict):
+        """
+        Parse constraint expressions and evaluate them, adding results to survey items.
+        """
+        for i, item in enumerate(survey_data["survey"]):
+            if "name" in item:
+                constraint_key = f"{item['name']}_constraint"
+                if constraint_key in self.ctx and self.ctx[constraint_key]["type"] == "constraint":
+                    value = self.ctx[constraint_key]["value"]
+                    try:
+                        # Evaluate the constraint expression
+                        constraint_result = eval(value)
+                        # Add constraint result to the survey item
+                        survey_data["survey"][i]["constraint_result"] = constraint_result
+                        survey_data["survey"][i]["constraint_expression"] = value
+                    except Exception as e:
+                        survey_data["survey"][i]["constraint_result"] = f"Error: {str(e)}"
+                        survey_data["survey"][i]["constraint_expression"] = value
+        
+        return survey_data
+
     def show_preview(self, outpath: str = None):
         """
         Generate a preview of the form output by parsing the YAML file and replacing variable references with their values.
@@ -211,6 +290,7 @@ class FormPreviewer:
         # Parse variables in the survey data
         self.output_data = self._parse_vars(self.output_data)
         self.output_data = self._parse_formulas(self.output_data)
+        self.output_data = self._parse_constraints(self.output_data)
 
         if outpath:
             # Save the parsed survey data to a file if outpath is provided

--- a/survey123py/preview.py
+++ b/survey123py/preview.py
@@ -82,7 +82,10 @@ class FormPreviewer:
             if matches:
                 for match in matches:
                     value = value.replace("${" + match + "}", str(ctx[match]["value"]))
-                ctx[item["name"]] = {"value": value, "type": item.get("type")}
+            # Handle modulo operator
+            if " mod " in value:
+                value = value.replace(" mod ", " % ")
+            ctx[item["name"]] = {"value": value, "type": item.get("type")}
         
         # Load constraint columns (handle dot operator here)
         for item in [x for x in self.output_data["survey"] if "constraint" in x]:
@@ -133,6 +136,12 @@ class FormPreviewer:
             if "version()" in value:
                 survey_settings = self.output_data.get("settings", {})
                 value = value.replace("version()", f"version({survey_settings})")
+            # Handle modulo operator
+            if " mod " in value:
+                value = value.replace(" mod ", " % ")
+            # Handle equality operator (Survey123 uses = but Python uses ==)
+            if " = " in value and " == " not in value:
+                value = value.replace(" = ", " == ")
             
             # Store constraint result in context for evaluation
             constraint_key = f"{item['name']}_constraint"
@@ -168,6 +177,9 @@ class FormPreviewer:
                 if "version()" in value_str:
                     survey_settings = self.output_data.get("settings", {})
                     value_str = value_str.replace("version()", f"version({survey_settings})")
+                # Handle modulo operator
+                if " mod " in value_str:
+                    value_str = value_str.replace(" mod ", " % ")
                 ctx[item["name"]]["value"] = eval(value_str)
                 if ctx[item["name"]]["type"] == "text" and not isinstance(ctx[item["name"]]["value"], bool):
                     # Need to escape quotes in the string so it can be used by eval() properly
@@ -261,6 +273,9 @@ class FormPreviewer:
                     if "version()" in value:
                         survey_settings = survey_data.get("settings", {})
                         value = value.replace("version()", f"version({survey_settings})")
+                    # Handle modulo operator
+                    if " mod " in value:
+                        value = value.replace(" mod ", " % ")
                     survey_data["survey"][i][key] = eval(value)
 
         return survey_data

--- a/tests/data/sample_survey_formulas.yaml
+++ b/tests/data/sample_survey_formulas.yaml
@@ -1,0 +1,18 @@
+settings:
+  form_title: Test Form
+survey:
+- label: What is your favorite fruit?
+  name: q1
+  survey123py::preview_input: Apple
+  type: text
+- label: What is your favorite color?
+  name: q2
+  survey123py::preview_input: Red
+  type: text
+- calculation: concat(${q1}, ' and ', ${q2})
+  label: Concat Calculation
+  name: outputCalculation
+  type: text
+- label: 'Concat Output is: ${outputCalculation}'
+  name: output
+  type: note

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -1,0 +1,118 @@
+import unittest
+from survey123py.form import FormData, Sheets
+from survey123py.preview import FormPreviewer
+from pathlib import Path
+import yaml
+import os
+
+
+class TestSurvey123_322_Preview(unittest.TestCase):
+
+    def setUp(self):
+        self.survey = FormData("3.22")
+        self.test_file = Path(__file__).parent / "data" / "sample_survey_formulas.yaml"
+        self.test_tmp_file = Path(__file__).parent / "data" / "test_tmp_input.yaml"
+        # self.test_tmpout_file = Path(__file__).parent / "data" / "test_tmp_output.yaml"
+        self.preview = FormPreviewer(str(self.test_file))
+        self.sheet_names = Sheets
+
+        self.tpl = {"settings": {"form_title": "Test Form"}, "survey": []}
+
+    def test_nested_formula(self):
+
+        tpl = self.tpl.copy()
+        val1 = "Apple"
+        val2 = "Red"
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "What is your favorite fruit?",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2",
+                "label": "What is your favorite color?",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Nested Calculation",
+                "calculation": "contains(concat(${q1}, ' and ', ${q2}), 'Apple')",
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation2",
+                "label": "Nested Calculation2",
+                "calculation": "contains(concat(${q1}, ' and ', ${q2}), 'Orange')",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Nested Output is: ${outputCalculation}",
+            },
+            {
+                "type": "note",
+                "name": "output2",
+                "label": "Nested Output is: ${outputCalculation2}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][4]["label"], f"Nested Output is: True", "Label not parsed correctly")
+        self.assertAlmostEqual(results["survey"][5]["label"], f"Nested Output is: False", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+
+
+    def test_concat(self):
+        tpl = self.tpl.copy()
+        val1 = "Apple"
+        val2 = "Red"
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "What is your favorite fruit?",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2",
+                "label": "What is your favorite color?",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Concat Calculation",
+                "calculation": "concat(${q1}, ' and ', ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Concat Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][3]["label"], f"Concat Output is: {val1} and {val2}", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+         
+

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -205,10 +205,43 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         # Cleanup
         os.remove(self.test_tmp_file)
 
-    def format_date(self):
+    def test_date(self):
+        tpl = self.tpl.copy()
+        val1 = "2017-05-28"
+        val1_ts = 1495900800000
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Input Date",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Date Calculation",
+                "calculation": "date(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Date Output is: ${outputCalculation}",
+            }
+        ]
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"Date Output is: {val1_ts}", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_format_date(self):
         tpl = self.tpl.copy()
         val1 = 1718371200000
-        val1_formatted = "2023-10-01"
+        val1_formatted = "2024-06-14"
 
         tpl["survey"] = [
             {

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -516,4 +516,63 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
         # Cleanup
         os.remove(self.test_tmp_file)
+    
+    def test_atan(self):
+        tpl = self.tpl.copy()
+        input_value = 1.5
+
+        tpl["survey"] = generate_test_survey("atan", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 0.9827937232473292, 5, msg="atan calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+    
+    def test_atan2(self):
+        tpl = self.tpl.copy()
+        val1 = 3.0  # y value
+        val2 = 4.0  # x value
+
+        tpl["survey"] = [
+            {
+                "type": "decimal",
+                "name": "q1",
+                "label": "Y coordinate",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "decimal", 
+                "name": "q2",
+                "label": "X coordinate",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Atan2 Calculation",
+                "calculation": "atan2(${q1}, ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Math output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][2]["calculation"], 0.6435011087932844, 5, msg="atan2 calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
 

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -5,6 +5,30 @@ from pathlib import Path
 import yaml
 import os
 
+def generate_math_formula_test_survey(formula: str, input_value: any):
+    """
+    Used to quickly generate a test survey for math formulas.
+    """
+    return [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Input for math calculation",
+                "survey123py::preview_input": input_value
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Acos Calculation",
+                "calculation": formula + "(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Math output is: ${outputCalculation}",
+            }
+        ]
+
 
 class TestSurvey123_322_Preview(unittest.TestCase):
 
@@ -78,7 +102,6 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         tpl = self.tpl.copy()
         val1 = "Apple"
         val2 = "Red"
-
         tpl["survey"] = [
             {
                 "type": "text",
@@ -117,27 +140,9 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
     def test_acos(self):
         tpl = self.tpl.copy()
-        val1 = 0.5
+        input_value = 0.5
 
-        tpl["survey"] = [
-            {
-                "type": "text",
-                "name": "q1",
-                "label": "Input for arc cosine calculation",
-                "survey123py::preview_input": val1
-            },
-            {
-                "type": "text",
-                "name": "outputCalculation",
-                "label": "Acos Calculation",
-                "calculation": "acos(${q1})",
-            },
-            {
-                "type": "note",
-                "name": "output",
-                "label": "Acos Output is: ${outputCalculation}",
-            }
-        ]
+        tpl["survey"] = generate_math_formula_test_survey("acos", input_value)
 
         with open(self.test_tmp_file, 'w') as file:
             yaml.dump(tpl, file)
@@ -152,27 +157,9 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
     def test_cos(self):
         tpl = self.tpl.copy()
-        val1 = 0.34
-
-        tpl["survey"] = [
-            {
-                "type": "text",
-                "name": "q1",
-                "label": "Input for cosine calculation",
-                "survey123py::preview_input": val1
-            },
-            {
-                "type": "text",
-                "name": "outputCalculation",
-                "label": "Cos Calculation",
-                "calculation": "cos(${q1})",
-            },
-            {
-                "type": "note",
-                "name": "output",
-                "label": "Cos Output is: ${outputCalculation}",
-            }
-        ]
+        input_value = 0.34
+        
+        tpl["survey"] = generate_math_formula_test_survey("cos", input_value)
 
         with open(self.test_tmp_file, 'w') as file:
             yaml.dump(tpl, file)
@@ -187,27 +174,9 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
     def test_sin(self):
         tpl = self.tpl.copy()
-        val1 = 1.5
+        input_value = 1.5
 
-        tpl["survey"] = [
-            {
-                "type": "text",
-                "name": "q1",
-                "label": "Input for sine calculation",
-                "survey123py::preview_input": val1
-            },
-            {
-                "type": "text",
-                "name": "outputCalculation",
-                "label": "Sin Calculation",
-                "calculation": "sin(${q1})",
-            },
-            {
-                "type": "note",
-                "name": "output",
-                "label": "Sin Output is: ${outputCalculation}",
-            }
-        ]
+        tpl["survey"] = generate_math_formula_test_survey("sin", input_value)
 
         with open(self.test_tmp_file, 'w') as file:
             yaml.dump(tpl, file)
@@ -219,5 +188,21 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
         # Cleanup
         os.remove(self.test_tmp_file)
-         
+    
+    def test_asin(self):
+        tpl = self.tpl.copy()
+        input_value = 0.56
+
+        tpl["survey"] = generate_math_formula_test_survey("asin", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 0.5943858000010622, 5, msg="asin calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
 

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -964,3 +964,215 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         with self.assertRaises(ValueError):
             sqrt(-1)
 
+    def test_selected(self):
+        tpl = self.tpl.copy()
+        val1 = "'option1,option3,option5'"  # Multi-select answer (comma-separated, quoted)
+        val2 = "option3"  # Choice to check
+
+        tpl["choices"] = [
+            {"list_name": "test_options", "name": "option1", "label": "Option 1"},
+            {"list_name": "test_options", "name": "option2", "label": "Option 2"},
+            {"list_name": "test_options", "name": "option3", "label": "Option 3"},
+            {"list_name": "test_options", "name": "option4", "label": "Option 4"},
+            {"list_name": "test_options", "name": "option5", "label": "Option 5"}
+        ]
+
+        tpl["survey"] = [
+            {
+                "type": "select_multiple test_options",
+                "name": "q1",
+                "label": "Multi-select question",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2",
+                "label": "Choice to check",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Selected Calculation",
+                "calculation": "selected(${q1}, ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Selected result is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][2]["calculation"], True, msg="selected calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_selected_false(self):
+        tpl = self.tpl.copy()
+        val1 = "'option1,option3,option5'"  # Multi-select answer (comma-separated, quoted)
+        val2 = "option2"  # Choice to check (not selected)
+
+        tpl["choices"] = [
+            {"list_name": "test_options", "name": "option1", "label": "Option 1"},
+            {"list_name": "test_options", "name": "option2", "label": "Option 2"},
+            {"list_name": "test_options", "name": "option3", "label": "Option 3"},
+            {"list_name": "test_options", "name": "option4", "label": "Option 4"},
+            {"list_name": "test_options", "name": "option5", "label": "Option 5"}
+        ]
+
+        tpl["survey"] = [
+            {
+                "type": "select_multiple test_options",
+                "name": "q1",
+                "label": "Multi-select question",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2",
+                "label": "Choice to check",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Selected Calculation",
+                "calculation": "selected(${q1}, ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Selected result is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][2]["calculation"], False, msg="selected calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_selected_at(self):
+        tpl = self.tpl.copy()
+        val1 = "'option1,option3,option5'"  # Multi-select answer (comma-separated, quoted)
+        val2 = 1  # Index to get
+
+        tpl["choices"] = [
+            {"list_name": "test_options", "name": "option1", "label": "Option 1"},
+            {"list_name": "test_options", "name": "option2", "label": "Option 2"},
+            {"list_name": "test_options", "name": "option3", "label": "Option 3"},
+            {"list_name": "test_options", "name": "option4", "label": "Option 4"},
+            {"list_name": "test_options", "name": "option5", "label": "Option 5"}
+        ]
+
+        tpl["survey"] = [
+            {
+                "type": "select_multiple test_options",
+                "name": "q1",
+                "label": "Multi-select question",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "integer",
+                "name": "q2",
+                "label": "Index to get",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Selected At Calculation",
+                "calculation": "selected_at(${q1}, ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Selected at result is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][2]["calculation"], "option3", msg="selected_at calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_selected_at_out_of_bounds(self):
+        tpl = self.tpl.copy()
+        val1 = "'option1,option3'"  # Multi-select answer with 2 items (comma-separated, quoted)
+        val2 = 5  # Index out of bounds
+
+        tpl["choices"] = [
+            {"list_name": "test_options", "name": "option1", "label": "Option 1"},
+            {"list_name": "test_options", "name": "option2", "label": "Option 2"},
+            {"list_name": "test_options", "name": "option3", "label": "Option 3"}
+        ]
+
+        tpl["survey"] = [
+            {
+                "type": "select_multiple test_options",
+                "name": "q1",
+                "label": "Multi-select question",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "integer",
+                "name": "q2",
+                "label": "Index to get",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Selected At Calculation",
+                "calculation": "selected_at(${q1}, ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Selected at result is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][2]["calculation"], "", msg="selected_at out of bounds calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_selected_empty_inputs(self):
+        """Test selected functions with empty inputs"""
+        from survey123py.formulas import selected, selected_at
+        
+        # Test selected with empty inputs
+        self.assertEqual(selected("", "option1"), False)
+        self.assertEqual(selected("option1,option2", ""), False)
+        self.assertEqual(selected("", ""), False)
+        
+        # Test selected_at with empty inputs
+        self.assertEqual(selected_at("", 0), "")
+        self.assertEqual(selected_at("option1,option2", -1), "")
+        self.assertEqual(selected_at("option1,option2", 10), "")
+

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -710,3 +710,257 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         # Cleanup
         os.remove(self.test_tmp_file)
 
+    def test_tan(self):
+        tpl = self.tpl.copy()
+        input_value = 0.785398  # π/4 radians
+
+        tpl["survey"] = generate_test_survey("tan", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 1.0000003465725653, 5, msg="tan calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_exp(self):
+        tpl = self.tpl.copy()
+        input_value = 2.0
+
+        tpl["survey"] = generate_test_survey("exp", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 7.38905609893065, 5, msg="exp calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_exp10(self):
+        tpl = self.tpl.copy()
+        input_value = 3.0
+
+        tpl["survey"] = generate_test_survey("exp10", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 1000.0, 5, msg="exp10 calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_log(self):
+        tpl = self.tpl.copy()
+        input_value = 2.71828  # approximately e
+
+        tpl["survey"] = generate_test_survey("log", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 0.9999986932206651, 5, msg="log calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_log10(self):
+        tpl = self.tpl.copy()
+        input_value = 1000.0
+
+        tpl["survey"] = generate_test_survey("log10", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 3.0, 5, msg="log10 calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_log_error_handling(self):
+        """Test that log functions raise ValueError for non-positive values"""
+        from survey123py.formulas import log, log10
+        
+        with self.assertRaises(ValueError):
+            log(0)
+        
+        with self.assertRaises(ValueError):
+            log(-1)
+            
+        with self.assertRaises(ValueError):
+            log10(0)
+            
+        with self.assertRaises(ValueError):
+            log10(-1)
+
+    def test_pi(self):
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Pi Calculation",
+                "calculation": "pi()",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Pi value is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][0]["calculation"], 3.141592653589793, 5, msg="pi calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_pow(self):
+        tpl = self.tpl.copy()
+        val1 = 2.0
+        val2 = 3.0
+
+        tpl["survey"] = [
+            {
+                "type": "decimal",
+                "name": "q1",
+                "label": "Base value",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "decimal", 
+                "name": "q2",
+                "label": "Exponent value",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Power Calculation",
+                "calculation": "pow(${q1}, ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Power result is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][2]["calculation"], 8.0, 5, msg="pow calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_round(self):
+        tpl = self.tpl.copy()
+        input_value = 3.14159
+
+        tpl["survey"] = generate_test_survey("round", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][1]["calculation"], 3.0, msg="round calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_round_with_digits(self):
+        tpl = self.tpl.copy()
+        val1 = 3.14159
+        val2 = 2
+
+        tpl["survey"] = [
+            {
+                "type": "decimal",
+                "name": "q1",
+                "label": "Value to round",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "integer",
+                "name": "q2",
+                "label": "Number of digits",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Round Calculation",
+                "calculation": "round(${q1}, ${q2})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Rounded result is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][2]["calculation"], 3.14, msg="round with digits calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_sqrt(self):
+        tpl = self.tpl.copy()
+        input_value = 16.0
+
+        tpl["survey"] = generate_test_survey("sqrt", input_value)
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 4.0, 5, msg="sqrt calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_sqrt_error_handling(self):
+        """Test that sqrt raises ValueError for negative values"""
+        from survey123py.formulas import sqrt
+        
+        with self.assertRaises(ValueError):
+            sqrt(-1)
+

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -96,7 +96,46 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         # Cleanup
         os.remove(self.test_tmp_file)
 
+    def test_if(self):
+        tpl = self.tpl.copy()
+        val1 = "Apple"
+        val2 = "Red"
 
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "What is your favorite fruit?",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2",
+                "label": "What is your favorite color?",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "If Calculation",
+                "calculation": "if(contains(${q1}, 'Apple'), 'Yep', 'Nope')",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "If Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][3]["label"], f"If Output is: Yep", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
 
     def test_concat(self):
         tpl = self.tpl.copy()

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -137,6 +137,109 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         # Cleanup
         os.remove(self.test_tmp_file)
 
+    def test_int(self):
+        tpl = self.tpl.copy()
+        val1 = 42
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Input for integer conversion",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Integer Conversion Calculation",
+                "calculation": "int(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Integer Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"Integer Output is: 42", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_boolean_from_string(self):
+        tpl = self.tpl.copy()
+        val1 = "true"
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Input for boolean conversion",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Boolean Conversion Calculation",
+                "calculation": "boolean_from_string(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Boolean Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"Boolean Output is: True", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def format_date(self):
+        tpl = self.tpl.copy()
+        val1 = 1718371200000
+        val1_formatted = "2023-10-01"
+
+        tpl["survey"] = [
+            {
+                "type": "date",
+                "name": "q1",
+                "label": "Input Date",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Format Date Calculation",
+                "calculation": "format-date(${q1}, '%Y-%m-%d')",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Formatted Date Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"Formatted Date Output is: {val1_formatted}", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
     def test_starts_with(self):
         tpl = self.tpl.copy()
         val1 = "Apple"
@@ -152,7 +255,7 @@ class TestSurvey123_322_Preview(unittest.TestCase):
                 "type": "text",
                 "name": "outputCalculation",
                 "label": "Starts With Calculation",
-                "calculation": "starts_with(${q1}, 'App')",
+                "calculation": "starts-with(${q1}, 'App')",
             },
             {
                 "type": "note",

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -2182,3 +2182,40 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         self.assertEqual(sum("abc", "def", None), 0, 
                         msg="Sum with all non-numeric should return 0")
 
+    def test_modulo_operator(self):
+        """Test modulo operator in constraints and calculations"""
+        tpl = self.tpl.copy()
+        
+        # Test modulo operator in calculation
+        tpl["survey"] = [
+            {"name": "input", "type": "integer", "survey123py::preview_input": 7},
+            {"name": "result", "type": "calculate", "calculation": "${input} mod 3"}
+        ]
+        
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][1]["calculation"], 1, 
+                        msg="Modulo operator in calculation not working correctly")
+        
+        # Test modulo operator in constraint (7 mod 2 = 1, which is not 0, so constraint should be False)
+        tpl["survey"] = [
+            {"name": "input", "type": "integer", "survey123py::preview_input": 7, 
+             "constraint": "${input} mod 2 = 0"}
+        ]
+        
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][0]["constraint_result"], False, 
+                        msg="Modulo operator in constraint not working correctly")
+        
+        # Cleanup
+        os.remove(self.test_tmp_file)
+

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -575,4 +575,138 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
         # Cleanup
         os.remove(self.test_tmp_file)
+    
+    def test_and_operator(self):
+        tpl = self.tpl.copy()
+        val1 = True
+        val2 = False
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Boolean value 1",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text", 
+                "name": "q2",
+                "label": "Boolean value 2",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "result_true_false",
+                "label": "And operation result",
+                "calculation": "${q1} and ${q2}",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Result is: ${result_true_false}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][2]["calculation"], False, msg="and operator not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_or_operator(self):
+        tpl = self.tpl.copy()
+        val1 = True
+        val2 = False
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Boolean value 1", 
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2", 
+                "label": "Boolean value 2",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "result_true_false",
+                "label": "Or operation result",
+                "calculation": "${q1} or ${q2}",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Result is: ${result_true_false}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][2]["calculation"], True, msg="or operator not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_and_or_combined(self):
+        tpl = self.tpl.copy()
+        val1 = True
+        val2 = False
+        val3 = True
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Boolean value 1",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2",
+                "label": "Boolean value 2", 
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "q3",
+                "label": "Boolean value 3",
+                "survey123py::preview_input": val3
+            },
+            {
+                "type": "text",
+                "name": "result_combined",
+                "label": "Combined and/or operation result",
+                "calculation": "(${q1} and ${q2}) or ${q3}",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Result is: ${result_combined}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        # (True and False) or True = False or True = True
+        self.assertEqual(results["survey"][3]["calculation"], True, msg="combined and/or operator not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
 

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import yaml
 import os
 
-def generate_math_formula_test_survey(formula: str, input_value: any):
+def generate_test_survey(formula: str, input_value: any):
     """
     Used to quickly generate a test survey for math formulas.
     """
@@ -137,6 +137,142 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         # Cleanup
         os.remove(self.test_tmp_file)
 
+    def test_starts_with(self):
+        tpl = self.tpl.copy()
+        val1 = "Apple"
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "What is your favorite fruit?",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Starts With Calculation",
+                "calculation": "starts_with(${q1}, 'App')",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Starts With Output is: ${outputCalculation}",
+            }
+        ]
+        
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"Starts With Output is: True", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_string_length(self):
+        tpl = self.tpl.copy()
+        val1 = "Apple"
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "What is your favorite fruit?",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "String Length Calculation",
+                "calculation": "string_length(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "String Length Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"String Length Output is: 5", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_string(self):
+        tpl = self.tpl.copy()
+        val1 = 12345
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "What is your favorite number?",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "String Conversion Calculation",
+                "calculation": "string(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "String Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"String Output is: 12345", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_substr(self):
+        tpl = self.tpl.copy()
+        val1 = "Apple"
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "What is your favorite fruit?",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Substring Calculation",
+                "calculation": "substr(${q1}, 1, 3)",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Substring Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        self.assertEqual(results["survey"][2]["label"], f"Substring Output is: ppl", "Label not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
     def test_concat(self):
         tpl = self.tpl.copy()
         val1 = "Apple"
@@ -181,7 +317,7 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         tpl = self.tpl.copy()
         input_value = 0.5
 
-        tpl["survey"] = generate_math_formula_test_survey("acos", input_value)
+        tpl["survey"] = generate_test_survey("acos", input_value)
 
         with open(self.test_tmp_file, 'w') as file:
             yaml.dump(tpl, file)
@@ -198,7 +334,7 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         tpl = self.tpl.copy()
         input_value = 0.34
         
-        tpl["survey"] = generate_math_formula_test_survey("cos", input_value)
+        tpl["survey"] = generate_test_survey("cos", input_value)
 
         with open(self.test_tmp_file, 'w') as file:
             yaml.dump(tpl, file)
@@ -215,7 +351,7 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         tpl = self.tpl.copy()
         input_value = 1.5
 
-        tpl["survey"] = generate_math_formula_test_survey("sin", input_value)
+        tpl["survey"] = generate_test_survey("sin", input_value)
 
         with open(self.test_tmp_file, 'w') as file:
             yaml.dump(tpl, file)
@@ -232,7 +368,7 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         tpl = self.tpl.copy()
         input_value = 0.56
 
-        tpl["survey"] = generate_math_formula_test_survey("asin", input_value)
+        tpl["survey"] = generate_test_survey("asin", input_value)
 
         with open(self.test_tmp_file, 'w') as file:
             yaml.dump(tpl, file)

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -114,5 +114,40 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
         # Cleanup
         os.remove(self.test_tmp_file)
+
+    def test_acos(self):
+        tpl = self.tpl.copy()
+        val1 = 0.5
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Input for arc cosine calculation",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Acos Calculation",
+                "calculation": "acos(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Acos Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 1.0471975511965979, 5, msg="acos calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
          
 

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -1504,3 +1504,425 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         with self.assertRaises(ValueError):
             decimal_date_time("invalid")
 
+    def test_false(self):
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "False Calculation",
+                "calculation": "false()",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][0]["calculation"], False, 
+                        msg="false() should return False")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_join(self):
+        tpl = self.tpl.copy()
+        val1 = "Apple"
+        val2 = "Orange"
+        val3 = ""  # Empty value (should be excluded)
+        separator = " - "
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Field 1",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "q2",
+                "label": "Field 2",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "text",
+                "name": "q3",
+                "label": "Field 3",
+                "survey123py::preview_input": val3
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Join Calculation",
+                "calculation": f"join('{separator}', ${'{q1}'}, ${'{q2}'}, ${'{q3}'})",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][3]["calculation"], "Apple - Orange", 
+                        msg="join should concatenate non-empty values with separator")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_max(self):
+        tpl = self.tpl.copy()
+        val1 = 10
+        val2 = 5
+        val3 = 15
+
+        tpl["survey"] = [
+            {
+                "type": "integer",
+                "name": "q1",
+                "label": "Number 1",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "integer",
+                "name": "q2",
+                "label": "Number 2",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "integer",
+                "name": "q3",
+                "label": "Number 3",
+                "survey123py::preview_input": val3
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Max Calculation",
+                "calculation": "max(${q1}, ${q2}, ${q3})",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][3]["calculation"], 15.0, 
+                        msg="max should return the largest value")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_min(self):
+        tpl = self.tpl.copy()
+        val1 = 10
+        val2 = 5
+        val3 = 15
+
+        tpl["survey"] = [
+            {
+                "type": "integer",
+                "name": "q1",
+                "label": "Number 1",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "integer",
+                "name": "q2",
+                "label": "Number 2",
+                "survey123py::preview_input": val2
+            },
+            {
+                "type": "integer",
+                "name": "q3",
+                "label": "Number 3",
+                "survey123py::preview_input": val3
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Min Calculation",
+                "calculation": "min(${q1}, ${q2}, ${q3})",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][3]["calculation"], 5.0, 
+                        msg="min should return the smallest value")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_not(self):
+        tpl = self.tpl.copy()
+        val1 = True
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Boolean value",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Not Calculation",
+                "calculation": "not(${q1})",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][1]["calculation"], False, 
+                        msg="not(True) should return False")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_now(self):
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Now Calculation",
+                "calculation": "now()",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        # Should return a timestamp in milliseconds (positive integer)
+        self.assertIsInstance(results["survey"][0]["calculation"], int, 
+                             msg="now() should return integer timestamp")
+        self.assertGreater(results["survey"][0]["calculation"], 0, 
+                          msg="now() should return positive timestamp")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_number(self):
+        tpl = self.tpl.copy()
+        val1 = "123.45"  # String that can be converted to number
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Text field with number",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Number Calculation",
+                "calculation": "number(${q1})",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][1]["calculation"], 123.45, 
+                        msg="number should convert string to float")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_additional_functions_error_handling(self):
+        """Test error handling for additional functions"""
+        from survey123py.formulas import false, join, max, min, not_, now, number
+        
+        # Test false (no arguments)
+        self.assertEqual(false(), False)
+        
+        # Test join with empty values
+        self.assertEqual(join("-", "", None, "value"), "value")
+        
+        # Test max/min with no valid numeric values
+        self.assertEqual(max("text", "", None), None)
+        self.assertEqual(min("text", "", None), None)
+        
+        # Test max/min with mixed numeric and non-numeric
+        self.assertEqual(max(1, "text", 3, ""), 3.0)
+        self.assertEqual(min(1, "text", 3, ""), 1.0)
+        
+        # Test not_ with various values
+        self.assertEqual(not_(True), False)
+        self.assertEqual(not_(False), True)
+        self.assertEqual(not_(1), False)
+        self.assertEqual(not_(0), True)
+        self.assertEqual(not_(""), True)
+        
+        # Test now returns reasonable timestamp
+        timestamp = now()
+        self.assertIsInstance(timestamp, int)
+        self.assertGreater(timestamp, 1600000000000)  # After 2020
+        
+        # Test number with invalid input
+        self.assertEqual(number("invalid"), None)
+        self.assertEqual(number(""), None)
+        self.assertEqual(number(None), None)
+
+    def test_dot_operator_in_constraint_with_numbers(self):
+        """Test dot operator in constraints with numeric fields"""
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "integer",
+                "name": "num_field",
+                "label": "Number field (must be > 5)",
+                "survey123py::preview_input": 8,
+                "constraint": ". > 5",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][0]["constraint_result"], True, 
+                        msg="Constraint with dot operator: 8 > 5 should be True")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_dot_operator_in_constraint_with_strings(self):
+        """Test dot operator in constraints with string fields"""
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "text_field",
+                "label": "Text field",
+                "survey123py::preview_input": "hello",
+                "constraint": "string_length(.) >= 3",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][0]["constraint_result"], True, 
+                        msg="String constraint with dot operator: length of 'hello' >= 3 should be True")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_dot_operator_constraint_false_condition(self):
+        """Test dot operator in constraints that evaluate to false"""
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "integer",
+                "name": "num_field",
+                "label": "Number field (must be < 10)",
+                "survey123py::preview_input": 15,
+                "constraint": ". < 10",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertEqual(results["survey"][0]["constraint_result"], False, 
+                        msg="Constraint with dot operator: 15 < 10 should be False")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_dot_operator_with_decimals_in_constraint(self):
+        """Test that dot operator doesn't interfere with decimal numbers in constraints"""
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "decimal",
+                "name": "decimal_field",
+                "label": "Decimal field",
+                "survey123py::preview_input": 7.5,
+                "constraint": ". >= 2.5 and . <= 10.0",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        # Should be: 7.5 >= 2.5 and 7.5 <= 10.0 = True
+        self.assertEqual(results["survey"][0]["constraint_result"], True, 
+                        msg="Constraint with decimals: 7.5 >= 2.5 and 7.5 <= 10.0 should be True")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+
+    def test_dot_operator_constraint_with_mixed_expressions(self):
+        """Test dot operator in constraints with mixed expressions including variables"""
+        tpl = self.tpl.copy()
+
+        tpl["survey"] = [
+            {
+                "type": "integer",
+                "name": "min_value",
+                "label": "Minimum value",
+                "survey123py::preview_input": 5
+            },
+            {
+                "type": "integer",
+                "name": "current_field",
+                "label": "Current field",
+                "survey123py::preview_input": 10,
+                "constraint": ". >= ${min_value}",
+            },
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        # Should be: 10 >= 5 = True
+        self.assertEqual(results["survey"][1]["constraint_result"], True, 
+                        msg="Mixed constraint expression: 10 >= 5 should be True")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
+

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -184,5 +184,40 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
         # Cleanup
         os.remove(self.test_tmp_file)
+
+    def test_sin(self):
+        tpl = self.tpl.copy()
+        val1 = 1.5
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Input for sine calculation",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Sin Calculation",
+                "calculation": "sin(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Sin Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 0.9974949866040544, 5, msg="sin calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
          
 

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -149,5 +149,40 @@ class TestSurvey123_322_Preview(unittest.TestCase):
 
         # Cleanup
         os.remove(self.test_tmp_file)
+
+    def test_cos(self):
+        tpl = self.tpl.copy()
+        val1 = 0.34
+
+        tpl["survey"] = [
+            {
+                "type": "text",
+                "name": "q1",
+                "label": "Input for cosine calculation",
+                "survey123py::preview_input": val1
+            },
+            {
+                "type": "text",
+                "name": "outputCalculation",
+                "label": "Cos Calculation",
+                "calculation": "cos(${q1})",
+            },
+            {
+                "type": "note",
+                "name": "output",
+                "label": "Cos Output is: ${outputCalculation}",
+            }
+        ]
+
+        with open(self.test_tmp_file, 'w') as file:
+            yaml.dump(tpl, file)
+        
+        preview = FormPreviewer(str(self.test_tmp_file))
+        results = preview.show_preview()
+        
+        self.assertAlmostEqual(results["survey"][1]["calculation"], 0.9427546655283462, 5, msg="cos calculation not parsed correctly")
+
+        # Cleanup
+        os.remove(self.test_tmp_file)
          
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -22,7 +22,7 @@ class TestSurvey123_322_Preview(unittest.TestCase):
         output_yaml = self.preview.show_preview()
         self.assertEqual(output_yaml["survey"][2]["label"], "Personal Data (John Doe)", "Label not parsed correctly")
         self.assertEqual(output_yaml["survey"][2]["children"][0]["label"], "Nationality of John Doe. Age 30", "Label not parsed correctly")
-        self.assertEqual(output_yaml["survey"][3]["label"], "The answers are John Doe and 30", "Label not parsed correctly")
+        self.assertEqual(output_yaml["survey"][3]["label"], "The answers are John Doe and 30", "Label not parsed correctly")      
 
     def test_invalid_parsing(self):
         # Test parsing an invalid survey file


### PR DESCRIPTION
Addresses #4.

I will be updating this PR and merging over time since it will take a lot of time to include each formula and test that it works correctly.

Take note of the TODO list below.

## Operator List:

- [x] And
- [x] Or
- [x] . (Current Answer in Field)
- [x] Modulus

## Functions List:

- [x] boolean
- [x] boolean-from-string
- [x] coalesce
- [x] concat
- [x] contains
- [x] count
- [x] count-selected
- [x] date
- [x] date-time
- [x] decimal-date-time
- [x] ends-with
- [x] false
- [x] format-date
- [x] if
- [ ] indexed-repeat
- [x] int
- [x] join
- [x] jr:choice-name
- [x] max
- [x] min
- [x] not
- [x] now
- [x] number
- [ ] once
- [ ] position
- [ ] pulldata("@exif")
- [ ] pulldata("@geopoint")
- [ ] pulldata("@json")
- [ ] pulldata("@layer")
- [ ] pulldata("@property")
- [x] random
- [x] regex
- [x] selected
- [x] selected-at
- [x] starts-with
- [x] string
- [x] string-length
- [x] substr
- [x] sum
- [x] today
- [x] uuid
- [x] version

## Mathematical Functions List

- [x] acos
- [x] asin
- [x] atan
- [x] atan2
- [x] cos
- [x] sin
- [x] tan
- [x] exp
- [x] exp10
- [x] log
- [x] log10
- [x] pi
- [x] pow
- [x] round
- [x] sqrt